### PR TITLE
Added binatray repo as resolver in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For more info see the see the [microsite](https://ackcord.katsstuff.net/), the e
 
 While AckCord is still in active development, you can try AckCord by adding some of these to your `build.sbt` file.
 ```scala
+resolvers += "binatray" at "http://jcenter.bintray.com"
 libraryDependencies += "net.katsstuff" %% "ackcord"                 % "0.12.0" //For high level API, includes all the other modules
 libraryDependencies += "net.katsstuff" %% "ackcord-core"            % "0.12.0" //Low level core API
 libraryDependencies += "net.katsstuff" %% "ackcord-commands-core"   % "0.12.0" //Low to mid level Commands API

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For more info see the see the [microsite](https://ackcord.katsstuff.net/), the e
 
 While AckCord is still in active development, you can try AckCord by adding some of these to your `build.sbt` file.
 ```scala
-resolvers += "binatray" at "http://jcenter.bintray.com"
+resolvers += Resolver.bintrayRepo("sedmelluq", "com.sedmelluq")
 libraryDependencies += "net.katsstuff" %% "ackcord"                 % "0.12.0" //For high level API, includes all the other modules
 libraryDependencies += "net.katsstuff" %% "ackcord-core"            % "0.12.0" //Low level core API
 libraryDependencies += "net.katsstuff" %% "ackcord-commands-core"   % "0.12.0" //Low to mid level Commands API

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For more info see the see the [microsite](https://ackcord.katsstuff.net/), the e
 
 While AckCord is still in active development, you can try AckCord by adding some of these to your `build.sbt` file.
 ```scala
-resolvers += Resolver.bintrayRepo("sedmelluq", "com.sedmelluq")
+resolvers += Resolver.JCenterRepository
 libraryDependencies += "net.katsstuff" %% "ackcord"                 % "0.12.0" //For high level API, includes all the other modules
 libraryDependencies += "net.katsstuff" %% "ackcord-core"            % "0.12.0" //Low level core API
 libraryDependencies += "net.katsstuff" %% "ackcord-commands-core"   % "0.12.0" //Low to mid level Commands API

--- a/doc/src/main/tut/getting_started.md
+++ b/doc/src/main/tut/getting_started.md
@@ -13,7 +13,7 @@ AckCord is a Scala library for Discord, using Akka. AckCord's focus is on lettin
 
 While AckCord is still in active development, you can try AckCord by adding some of these to your `build.sbt` file.
 ```scala
-resolvers += Resolver.bintrayRepo("sedmelluq", "com.sedmelluq")
+resolvers += Resolver.JCenterRepository
 libraryDependencies += "net.katsstuff" %% "ackcord"                 % "{{versions.ackcord}}" //For high level API, includes all the other modules
 libraryDependencies += "net.katsstuff" %% "ackcord-core"            % "{{versions.ackcord}}" //Low level core API
 libraryDependencies += "net.katsstuff" %% "ackcord-commands-core"   % "{{versions.ackcord}}" //Low to mid level Commands API

--- a/doc/src/main/tut/getting_started.md
+++ b/doc/src/main/tut/getting_started.md
@@ -13,6 +13,7 @@ AckCord is a Scala library for Discord, using Akka. AckCord's focus is on lettin
 
 While AckCord is still in active development, you can try AckCord by adding some of these to your `build.sbt` file.
 ```scala
+resolvers += Resolver.bintrayRepo("sedmelluq", "com.sedmelluq")
 libraryDependencies += "net.katsstuff" %% "ackcord"                 % "{{versions.ackcord}}" //For high level API, includes all the other modules
 libraryDependencies += "net.katsstuff" %% "ackcord-core"            % "{{versions.ackcord}}" //Low level core API
 libraryDependencies += "net.katsstuff" %% "ackcord-commands-core"   % "{{versions.ackcord}}" //Low to mid level Commands API

--- a/doc/src/main/tut/modules.md
+++ b/doc/src/main/tut/modules.md
@@ -11,7 +11,7 @@ While the modules listed at the start are the main modules you want to depend on
 
 ### Make sure to add the following line to your SBT file :
 ```scala
-resolvers += Resolver.bintrayRepo("sedmelluq", "com.sedmelluq")
+resolvers += Resolver.JCenterRepository
 ```
 
 ---

--- a/doc/src/main/tut/modules.md
+++ b/doc/src/main/tut/modules.md
@@ -9,6 +9,13 @@ While the modules listed at the start are the main modules you want to depend on
 
 {% assign versions = site.data.versions %}
 
+### Make sure to add the following line to your SBT file :
+```scala
+resolvers += Resolver.bintrayRepo("sedmelluq", "com.sedmelluq")
+```
+
+---
+
 ## ackcord-data
 ```scala
 libraryDependencies += "net.katsstuff" %%% "ackcord-data" % "{{versions.ackcord}}"


### PR DESCRIPTION
I just added this resolver as I just had this issue while trying to import dependencies... It would fail for the lavaplay dependency, searching it at `https://repo1.maven.org/maven2` instead of `http://jcenter.bintray.com`.
It might just come from my IntelliJ configuration though, I didn't spent much time investigating to be honest