### PR TITLE
Replace deprecated discordapp.com with discord.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ The AckCord module map
 
 Lastly, join our Discord server (we got cookies).
 
-[![](https://discordapp.com/api/guilds/399373512072232961/embed.png?style=banner1)](https://discord.gg/5UH627u) 
+[![](https://discord.com/api/guilds/399373512072232961/embed.png?style=banner1)](https://discord.gg/5UH627u) 

--- a/data/src/main/scala/ackcord/data/WidgetImageStyle.scala
+++ b/data/src/main/scala/ackcord/data/WidgetImageStyle.scala
@@ -29,7 +29,7 @@ import enumeratum.values.{StringEnum, StringEnumEntry}
 
 /**
   * A style the widget image might be shown as.
-  * See examples here. https://discordapp.com/developers/docs/resources/guild#get-guild-widget-image
+  * See examples here. https://discord.com/developers/docs/resources/guild#get-guild-widget-image
   */
 sealed abstract class WidgetImageStyle(val value: String) extends StringEnumEntry
 object WidgetImageStyle extends StringEnum[WidgetImageStyle] {

--- a/docs/src/main/mdoc/docs/advanced/sound.md
+++ b/docs/src/main/mdoc/docs/advanced/sound.md
@@ -13,7 +13,7 @@ With that out of the way, let's talk sound. If you want to send sound with
 AckCord, you currently have to wire some stuff up yourself. AckCord still hides 
 most of the implementations, but you are assumed to have some knowledge of how 
 sound sending works in Discord. If you are not familiar with this, read 
-the [Discord docs for voice connections](https://discordapp.com/developers/docs/topics/voice-connections).
+the [Discord docs for voice connections](https://discord.com/developers/docs/topics/voice-connections).
 
 ## Establishing a connection
 The first thing you need to do is to tell Discord that you want to begin 

--- a/docs/src/main/mdoc/docs/low-level/first_bot.md
+++ b/docs/src/main/mdoc/docs/low-level/first_bot.md
@@ -21,7 +21,7 @@ import ackcord.data._
 ```
 
 Next we need a bot token. You can get one by going to 
-[https://discordapp.com/developers/applications](https://discordapp.com/developers/applications), 
+[https://discord.com/developers/applications](https://discord.com/developers/applications), 
 creating a new application, and then creating a bot for your application.
 ```scala mdoc:silent
 val token = "<token>" //Your Discord token. Be very careful to never give this to anyone else

--- a/docs/src/main/mdoc/first_bot.md
+++ b/docs/src/main/mdoc/first_bot.md
@@ -25,7 +25,7 @@ import scala.concurrent.duration.Duration
 ```
 
 Next we need a bot token. You can get one by going to 
-[https://discordapp.com/developers/applications](https://discordapp.com/developers/applications), 
+[https://discord.com/developers/applications](https://discord.com/developers/applications), 
 creating a new application, and then creating a bot for your application.
 ```scala mdoc:silent
 val token = "<token>" //Your Discord token. Be very careful to never give this to anyone else

--- a/docs/src/main/mdoc/index.md
+++ b/docs/src/main/mdoc/index.md
@@ -29,4 +29,4 @@ For more information, either see the the examples or the ScalaDoc.
 
 Or you can just join the Discord server (we got cookies).
 
-[![](https://discordapp.com/api/guilds/399373512072232961/embed.png?style=banner1)](https://discord.gg/5UH627u) 
+[![](https://discord.com/api/guilds/399373512072232961/embed.png?style=banner1)](https://discord.gg/5UH627u) 

--- a/requests/src/main/scala/ackcord/requests/Routes.scala
+++ b/requests/src/main/scala/ackcord/requests/Routes.scala
@@ -36,7 +36,7 @@ import shapeless._
   */
 object Routes {
 
-  val discord = "discordapp.com"
+  val discord = "discord.com"
 
   val base: Route =
     Route(


### PR DESCRIPTION
Replaces discordapp.com in all the documentation and the main Routes.scala file as it will eventually be removed completely.