### PR TITLE
stop LavaplayerHandler actor when associated player is destroyed

### DIFF
--- a/ackCord/src/main/scala/ackcord/MusicManager.scala
+++ b/ackCord/src/main/scala/ackcord/MusicManager.scala
@@ -61,16 +61,19 @@ object MusicManager {
       apply(events, players.updated(guildId, (usedPlayer, actor)))
 
     case (_, DisconnectFromChannel(guildId, destroyPlayer)) =>
-      players.get(guildId).foreach {
-        case (player, actor) =>
+      players.get(guildId) match {
+        case Some((player, actor)) =>
           actor ! LavaplayerHandler.DisconnectVoiceChannel
 
           if (destroyPlayer) {
             player.destroy()
+            actor ! LavaplayerHandler.Shutdown
+            apply(events, players - guildId)
+          } else {
+            Behaviors.same
           }
+        case None => Behaviors.same
       }
-
-      apply(events, players - guildId)
 
     case (_, SetChannelPlaying(guildId, playing)) =>
       players.get(guildId).foreach {


### PR DESCRIPTION
## Existing Behavior

When `MusicManager` connects to a channel, it updates its own map of `GuildId` to `(AudioPlayer, ActorRef[LavaplayerHandler.Command])` with the new guild. When a `DisconnectFromChannel` command is sent the reference is removed from the players map in all cases (whether or not the player is destroyed) and the actor is left alive.  When `ConnectToChannel` is called for a second time for the same `GuildId`, there's no reference to the player/actor in the map and it attempts to create a new actor with the same guild id which leads akka to throw an exception for a non-unique name.

## New Behavior

On disconnect if `destroyPlayer` is set to `true`, the associated actor is also shutdown and the reference in the players map is removed. In all other cases the behavior is kept the same and the `LavaplayerHandler` actor is left running.