### PR TITLE
Fixed User.mention bug

### DIFF
--- a/data/src/main/scala/ackcord/data/message.scala
+++ b/data/src/main/scala/ackcord/data/message.scala
@@ -171,7 +171,7 @@ case class User(
   /**
     * Mention this user.
     */
-  def mention: String = s"<@$id>"
+  def mention: String = s"<@!$id>"
 
   /**
     * Mention this user with their nickname.


### PR DESCRIPTION
Fixed the small issue of the `mention` method. The correct mention format is e.g. `<@!196689826697707520>`, however, the `!` is not present in the current version of the method.